### PR TITLE
Add config to secret

### DIFF
--- a/src/doc_ingestion_pipeline/beam/pipelines/process_pdf.py
+++ b/src/doc_ingestion_pipeline/beam/pipelines/process_pdf.py
@@ -9,7 +9,6 @@ from apache_beam.transforms.display import DisplayDataItem
 from doc_ingestion_pipeline.beam.dofunctions import process_pdf_dofn as dofn
 from doc_ingestion_pipeline.beam.dofunctions.base_dofn import BaseDoFn
 from doc_ingestion_pipeline.utils.app_logging import LoggerHandler
-from doc_ingestion_pipeline.utils.file_handling import read_yaml
 
 
 class ProcessPDFPipelineOptions(PipelineOptions):
@@ -90,8 +89,9 @@ class ProcessPdfPipeline(BaseDoFn, beam.Pipeline):
 
 
 if __name__ == "__main__":
+    from doc_ingestion_pipeline.utils.file_handling import get_gcp_secrets
 
-    app_configs = read_yaml("assets/configs/app-configs.yaml")
+    app_configs = get_gcp_secrets("150030916493", "doc-ingestion-pipeline-secrets")
     logger_handler = LoggerHandler(
         logger_name="PDF-INGESTION-PIPELINE", logging_type="gcp_console"
     )

--- a/src/doc_ingestion_pipeline/utils/file_handling.py
+++ b/src/doc_ingestion_pipeline/utils/file_handling.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 import yaml
+from google.cloud import secretmanager
 
 
 def read_yaml(path: str) -> dict:
@@ -32,3 +33,12 @@ def clear_folder(path: str):
             logging.error(f"Failed to delete {item_path}: {e}")
 
     logging.info(f"All files and folders in '{path}' have been cleared.")
+
+
+def get_gcp_secrets(project_id: str, secret_id: str, version_id="latest"):
+
+    client = secretmanager.SecretManagerServiceClient()
+    name = f"projects/{project_id}/secrets/{secret_id}/versions/{version_id}"
+    response = client.access_secret_version(name=name)
+    gcp_secrets = yaml.safe_load(response.payload.data.decode("UTF-8"))
+    return gcp_secrets

--- a/src/setup.py
+++ b/src/setup.py
@@ -39,6 +39,7 @@ dependencies = [
     "scikit-learn==1.5.1",
     "google-cloud-storage==2.19.0",
     "google-cloud-logging==3.11.4",
+    "google-cloud-secret-manager==2.10.0",
     "uvicorn==0.34.0",
     "fastapi==0.115.6",
     "langchain-google-vertexai==2.0.12",


### PR DESCRIPTION
now the configs are pulled from GCP cloud secrets and not from yaml file directly anymore.


then the steps to deploy are as follows:

1. Provision all GCP resouces need by project run provisioning.sh as example below:
```sh
src/bash/provisioning.sh \
   --env dev \
   --mode "CREATE"\
   --project-id "the-bot-specialist-dev" \
   --project-number "150030916493" \
   --region "us-central1" \
   --location "US" \
   --cloud-function-name "trigger-pdf-ingestion-dataflow-job"\
   --cron-job-name "trigger-pdf-ingestion-schedule" \
   --cron-shedule "50 16 * * *" \
   --cron-timezone "America/Sao_Paulo"
``` 

2. Then exanche manually on app-configs.yaml the alloyDB instance public ID created on provisioning.sh
```yaml
CONNECTIONS:
  ALLOYDB:
    DEV:
      connection_name: "the-bot-specialist-dev:us-central1:vector-store-dev"
      region: "us-central1"
      cluster: "cluster-us-central1-dev"
      instance: "cluster-us-central1-instance1-dev"
      database: "postgres"
      table_name: "bot-brain"
      project_id: "the-bot-specialist-dev"
      db_schema: "public"
      db_host: "<ALLOYDB-INSTANCE-PUBLIC-IP>" # ←  put here  the new public ip address create where
      db_user: "<ALLOY_DB_USER>"
      db_password: "<PASSWORD>"
      db_port: 5432
      db_name: "postgres"
      use_private_ip: False
```
3. Upload config file to cloud secrets and name it as 'doc-ingestion-pipeline-secrets'

4. Go to AlloyDB Studio and run the following query using 'user-dev' credentials, then run the query below there:
```sql
    CREATE EXTENSION vector;
    DROP TABLE IF EXISTS "bot-brain";
    CREATE TABLE "bot-brain" (
      id VARCHAR(150),
      text VARCHAR(5000),
      page_number INTEGER,
      source_doc VARCHAR(100),
      embedding vector(768),
      topics VARCHAR[]
);
```

5. Then run all process to setup pipeline running setup_pipeline.sh as follows:
```sh
src/bash/pipeline_setup.sh \
	--env "dev" \
	--registry-repo-name "bot-especialist-repo" \
	--container-image "doc-ingestion-pipeline-dev:v1.1" \
	--project-id "the-bot-specialist-dev" \
	--project-number "150030916493" \
	--region "us-central1"
```
6. To test doc ingestion pipeline dataflow job, go to cloud schedule and click on option force run on 'trigger-pdf-ingestion-dataflow-job'

7. Check logs, check if dataflow job runned as expected, finally check if 'bot-brain' was populated running this query on alloyDB Studio:

```sql
SELECT * from bot-brain;
```
